### PR TITLE
Refactor backend to allow for asynchronous execution

### DIFF
--- a/qoqo-iqm/src/backend.rs
+++ b/qoqo-iqm/src/backend.rs
@@ -263,37 +263,38 @@ impl BackendWrapper {
     }
 
     /// TODO
-    pub fn query_measurement_results(
+    pub fn get_measurement_results(
         &self,
         id: String,
         measurement: &PyAny,
     ) -> PyResult<Option<HashMap<String, f64>>> {
-        let 
     }
 
-    /// Submit a measurement to the backend without fetching the results immediately.
+    /// Submit a measurement to the backend for asynchronous execution.
     ///
     /// Args:
     ///     measurement (Measurement): The measurement that is submitted to the backend.
     ///
     /// Returns:
-    ///     Tuple[str, Dict[str, List[int]]]: Job ID to retrieve the results, and map of the
-    ///     measured qubits for each output register, needed to process the results of the backend.
+    ///     str: Job ID to retrieve the results
     ///
     /// Raises:
     ///     RuntimeError: Something went wrong when submitting the job to the backend.
-    pub fn submit_measurement(
-        &self,
-        measurement: &PyAny,
-    ) -> PyResult<(String, HashMap<String, Vec<usize>>)> {
+    pub fn submit_measurement(&self, measurement: &PyAny) -> PyResult<String> {
         let circuit_batch = get_circuit_list_from_measurement(measurement).map_err(|err| {
             PyRuntimeError::new_err(format!(
-                "Something went wrong when submitting the job to the backend: {:?}",
+                "Something went wrong when extracting the circuit list from the measurement: {:?}",
                 err
             ))
         })?;
         self.internal
-            .submit_circuit_batch(circuit_batch, bit_registers)?;
+            .submit_circuit_batch(circuit_batch, bit_registers)
+            .map_err(|err| {
+                PyRuntimeError::new_err(format!(
+                    "Something went wrong when submitting the job to the backend: {:?}",
+                    err
+                ))
+            })
     }
 }
 

--- a/qoqo-iqm/src/backend.rs
+++ b/qoqo-iqm/src/backend.rs
@@ -232,13 +232,15 @@ impl BackendWrapper {
     ///     TypeError: Circuit argument cannot be converted to qoqo Circuit
     ///     RuntimeError: Running Circuit failed
     pub fn run_measurement_registers(&self, measurement: &PyAny) -> PyResult<Registers> {
-        let circuit_list = get_circuit_list_from_measurement(measurement)?;
-        self.internal.run_circuit_list(circuit_list).map_err(|err| {
-            PyRuntimeError::new_err(format!(
-                "Something went wrong when running the list of circuits: {:?}",
-                err
-            ))
-        })
+        let circuit_batch = get_circuit_list_from_measurement(measurement)?;
+        self.internal
+            .run_circuit_batch(circuit_batch)
+            .map_err(|err| {
+                PyRuntimeError::new_err(format!(
+                    "Something went wrong when running the list of circuits: {:?}",
+                    err
+                ))
+            })
     }
 
     /// Runs a measurement with the IQM backend and waits for results.

--- a/qoqo-iqm/tests/integration/backend.rs
+++ b/qoqo-iqm/tests/integration/backend.rs
@@ -39,7 +39,7 @@ fn test_creating_backend_deneb_device() {
             .unwrap();
     });
 
-    if env::var("IQM_TOKENS_FILE").is_ok() {
+    if env::var("IQM_TOKEN").is_ok() {
         // Test if Backend correctly retrieves access token from environment variable
         Python::with_gil(|py| {
             let device_type = py.get_type::<devices::DenebDeviceWrapper>();
@@ -56,7 +56,7 @@ fn test_creating_backend_deneb_device() {
                 .unwrap();
         })
     } else {
-        // If the environment variable IQM_TOKENS_FILE is not set and an access token is not provided, creation of the Backend should fail
+        // If the environment variable IQM_TOKEN is not set and an access token is not provided, creation of the Backend should fail
         Python::with_gil(|py| {
             let device_type = py.get_type::<devices::DenebDeviceWrapper>();
             let device = device_type
@@ -97,7 +97,7 @@ fn test_creating_backend_resonator_free_device() {
             .unwrap();
     });
 
-    if env::var("IQM_TOKENS_FILE").is_ok() {
+    if env::var("IQM_TOKEN").is_ok() {
         // Test if Backend correctly retrieves access token from environment variable
         Python::with_gil(|py| {
             let device_type = py.get_type::<devices::ResonatorFreeDeviceWrapper>();
@@ -114,7 +114,7 @@ fn test_creating_backend_resonator_free_device() {
                 .unwrap();
         })
     } else {
-        // If the environment variable IQM_TOKENS_FILE is not set and an access token is not provided, creation of the Backend should fail
+        // If the environment variable IQM_TOKEN is not set and an access token is not provided, creation of the Backend should fail
         Python::with_gil(|py| {
             let device_type = py.get_type::<devices::ResonatorFreeDeviceWrapper>();
             let device = device_type

--- a/roqoqo-iqm/src/backend.rs
+++ b/roqoqo-iqm/src/backend.rs
@@ -867,9 +867,11 @@ mod tests {
             "reg2".to_string(),
             vec![vec![false, false, false], vec![false, false, false]],
         );
+
         let mut iqm_results = HashMap::new();
         iqm_results.insert("reg1".to_string(), vec![vec![0, 1, 0], vec![1, 1, 0]]);
         iqm_results.insert("reg2".to_string(), vec![vec![1, 1], vec![1, 0]]);
+
         let mut measured_qubits_map = HashMap::new();
         measured_qubits_map.insert("reg1".to_string(), vec![0, 2, 4]);
         measured_qubits_map.insert("reg2".to_string(), vec![1, 2]);

--- a/roqoqo-iqm/src/backend.rs
+++ b/roqoqo-iqm/src/backend.rs
@@ -379,15 +379,12 @@ impl Backend {
                 msg: format!("Error during GET request: {:?}", e),
             })?;
 
-        let iqm_result = result.json::<IqmRunResult>();
-        let iqm_result = match iqm_result {
-            Ok(res) => res,
-            Err(e) => {
-                return Err(RoqoqoBackendError::NetworkError {
-                    msg: format!("Error during deserialisation of GET response: {:?}", e),
-                });
-            }
-        };
+        let iqm_result =
+            result
+                .json::<IqmRunResult>()
+                .map_err(|err| RoqoqoBackendError::NetworkError {
+                    msg: format!("Error during deserialisation of GET response: {:?}", err),
+                })?;
 
         if iqm_result.warnings.is_some() {
             eprintln!("Warnings: {:?}", iqm_result.clone().warnings.unwrap());
@@ -754,8 +751,10 @@ fn get_measured_qubits_map(results: &IqmRunResult) -> Result<MeasuredQubitsMap, 
 ///
 /// `Ok(Registers)` - The output registers constructed by processing the results.
 /// `Err(IqmBackendError)` - Something went wrong with the processing of the results.
-#[inline]
-fn results_to_registers(results: IqmRunResult, id: String) -> Result<Registers, IqmBackendError> {
+pub fn results_to_registers(
+    results: IqmRunResult,
+    id: String,
+) -> Result<Registers, IqmBackendError> {
     let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
     let float_registers: HashMap<String, FloatOutputRegister> = HashMap::new();
     let complex_registers: HashMap<String, ComplexOutputRegister> = HashMap::new();

--- a/roqoqo-iqm/src/interface.rs
+++ b/roqoqo-iqm/src/interface.rs
@@ -21,6 +21,11 @@ use roqoqo::RoqoqoBackendError;
 
 use crate::IqmBackendError;
 
+// HashMap that associates to each register name the indices in the register that are being affected
+// by measurements, and the length of the register. This information is needed to post process the
+// results returned by the server.
+pub(crate) type MeasuredQubitsMap = HashMap<String, (Vec<usize>, usize)>;
+
 // Pragma operations that are ignored by backend and do not throw an error
 const ALLOWED_OPERATIONS: &[&str; 8] = &[
     "PragmaBoostNoise",
@@ -60,11 +65,6 @@ pub struct IqmInstruction {
     /// results into roqoqo registers.
     pub args: HashMap<String, CalculatorFloat>,
 }
-
-// HashMap that associates to each register name the indices in the register that are being affected
-// by measurements. These indices are saved in the order in which the measurement operations appear
-// in the circuit, since this is the order in which the backend returns the results.
-pub(crate) type MeasuredQubitsMap = HashMap<String, (Vec<usize>, usize)>;
 
 /// Converts all operations in a [roqoqo::Circuit] into instructions for IQM Hardware.
 ///

--- a/roqoqo-iqm/src/interface.rs
+++ b/roqoqo-iqm/src/interface.rs
@@ -20,6 +20,8 @@ use roqoqo::operations::*;
 use roqoqo::registers::BitOutputRegister;
 use roqoqo::RoqoqoBackendError;
 
+use crate::IqmBackendError;
+
 // Pragma operations that are ignored by backend and do not throw an error
 const ALLOWED_OPERATIONS: &[&str; 8] = &[
     "PragmaBoostNoise",
@@ -42,8 +44,7 @@ pub struct IqmCircuit {
     pub name: String,
     /// Vector of instructions accepted by the IQM REST API
     pub instructions: Vec<IqmInstruction>,
-    // TODO
-    // pub metadata : Option<HashMap< String, String >>,
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 /// Representation for instructions accepted by the IQM REST API
@@ -64,26 +65,29 @@ pub struct IqmInstruction {
 // in the circuit, since this is the order in which the backend returns the results.
 pub(crate) type RegisterMapping = HashMap<String, Vec<usize>>;
 
-/// Converts all operations in a [roqoqo::Circuit] into instructions for IQM Hardware or IQM Simulators
+/// Converts all operations in a [roqoqo::Circuit] into instructions for IQM Hardware.
 ///
 /// # Arguments
 ///
 /// * `circuit` - The [roqoqo::Circuit] that is converted
-/// * `device_number_qubits` - The number of qubits of the backend device. It is used to know how many qubits to measure with [roqoqo::operations::PragmaRepeatedMeasurement]
+/// * `device_number_qubits` - The number of qubits of the backend device. It is used to know how
+///    many qubits to measure with [roqoqo::operations::PragmaRepeatedMeasurement]
 /// * `output_registers` - A mutable reference to the classical registers that need to be initialized
 /// * `number_measurements_internal` - If set, the number of measurements that has been overwritten
 /// in the backend
 ///
 /// # Returns
 ///
-/// * `Ok(IqmCircuit, RegisterMapping, usize)` - Converted circuit, mapping of measured qubits to register indices, and number of measurements
-/// * `Err(RoqoqoBackendError::OperationNotInBackend)` - Error when [roqoqo::operations::Operation] can not be converted
+/// * `Ok(IqmCircuit, RegisterMapping, usize)` - Converted circuit, mapping of measured qubits to
+///    register indices, and number of measurements
+/// * `Err(RoqoqoBackendError::OperationNotInBackend)` - Error when [roqoqo::operations::Operation]
+///    can not be converted
 pub fn call_circuit<'a>(
     circuit: impl Iterator<Item = &'a Operation>,
     device_number_qubits: usize,
     output_registers: &mut HashMap<String, BitOutputRegister>,
     number_measurements_internal: Option<usize>,
-) -> Result<(IqmCircuit, RegisterMapping, usize), RoqoqoBackendError> {
+) -> Result<(IqmCircuit, RegisterMapping, usize), IqmBackendError> {
     let mut circuit_vec: Vec<IqmInstruction> = Vec::new();
     let mut number_measurements: usize = 1;
     let mut measured_qubits: Vec<usize> = vec![];
@@ -92,11 +96,11 @@ pub fn call_circuit<'a>(
     for op in circuit {
         match op {
             Operation::DefinitionBit(o) => {
+                let name = (*o).name().to_string();
                 // initialize output registers with default `false` values
                 if *o.is_output() {
-                    output_registers
-                        .insert((*o).name().to_string(), vec![vec![false; *o.length()]]);
-                    register_mapping.insert((*o).name().to_string(), vec![]);
+                    output_registers.insert(name, vec![vec![false; *o.length()]]);
+                    register_mapping.insert(name, vec![]);
                 }
             }
             Operation::MeasureQubit(o) => {
@@ -106,7 +110,7 @@ pub fn call_circuit<'a>(
                 match register_mapping.get_mut(&readout) {
                     Some(x) => x.push(*o.readout_index()),
                     None => {
-                        return Err(RoqoqoBackendError::GenericError {
+                        return Err(IqmBackendError::InvalidCircuit {
                             msg: "A MeasureQubit operation is writing to an undefined register."
                                 .to_string(),
                         })
@@ -115,32 +119,23 @@ pub fn call_circuit<'a>(
                 let mut found: bool = false;
                 // Check if we already have a measurement to the same register
                 // if yes, add the qubit being measured to that measurement
-                for instr in &mut circuit_vec {
-                    if instr.name == "measure" {
-                        let meas_readout =
-                            instr
-                                .args
-                                .get("key")
-                                .ok_or(RoqoqoBackendError::GenericError {
-                                msg: "A measurement must contain a `key` entry in the `args` field"
-                                    .to_string(),
-                            })?;
-                        if let CalculatorFloat::Str(s) = meas_readout {
-                            if s == &readout {
-                                found = true;
-                                let iqm_qubit = _convert_qubit_name_qoqo_to_iqm(*o.qubit());
-                                if !instr.qubits.contains(&iqm_qubit) {
-                                    instr.qubits.push(iqm_qubit);
-                                } else {
-                                    return Err(RoqoqoBackendError::GenericError {
-                                        msg: format!(
-                                            "Qubit {} is being measured twice.",
-                                            *o.qubit()
-                                        ),
-                                    });
-                                }
-                                break;
+                for instr in circuit_vec.iter_mut().filter(|&x| x.name == "measure") {
+                    let meas_readout = instr.args.get("key").expect(
+                        "An IqmInstruction measurement must contain a `key` entry in \
+                                     the `args` field.",
+                    );
+                    if let CalculatorFloat::Str(s) = meas_readout {
+                        if s == &readout {
+                            found = true;
+                            let iqm_qubit = _convert_qubit_name_qoqo_to_iqm(*o.qubit());
+                            if !instr.qubits.contains(&iqm_qubit) {
+                                instr.qubits.push(iqm_qubit);
+                            } else {
+                                return Err(IqmBackendError::InvalidCircuit {
+                                    msg: format!("Qubit {} is being measured twice.", *o.qubit()),
+                                });
                             }
+                            break;
                         }
                     }
                 }
@@ -149,7 +144,7 @@ pub fn call_circuit<'a>(
                     let meas = IqmInstruction {
                         name: "measure".to_string(),
                         qubits: vec![_convert_qubit_name_qoqo_to_iqm(*o.qubit())],
-                        args: HashMap::from([("key".to_string(), CalculatorFloat::Str(readout))]),
+                        args: HashMap::from([("key".to_string(), readout.into())]),
                     };
                     circuit_vec.push(meas)
                 }
@@ -158,80 +153,76 @@ pub fn call_circuit<'a>(
                 // if number_measurements > 1, it means that it has already been set by either a
                 // PragmaSetNumberOfMeasurements or a PragmaRepeatedMeasurement
                 if number_measurements > 1 {
-                    return Err(RoqoqoBackendError::GenericError {
+                    return Err(IqmBackendError::InvalidCircuit {
                         msg: "Only one repeated measurement is allowed in the circuit.".to_string(),
                     });
                 }
-
                 number_measurements = *o.number_measurements();
+
                 let readout = o.readout().clone();
+                let readout_register = output_registers.get(&readout);
 
-                if !output_registers.contains_key(&readout) {
-                    return Err(RoqoqoBackendError::GenericError {
-                        msg: format!(
-                            "PragmaSetNumberOfMeasurements writes to an undefined register {}",
-                            &readout
-                        ),
-                    });
-                } else {
-                    let readout_length = match output_registers
-                        .get(&readout)
-                        .expect("PragmaSetNumberOfMeasurements writes to an undefined register.")
-                        .first()
-                    {
-                        Some(v) => v.len(),
-                        None => {
-                            return Err(RoqoqoBackendError::GenericError {
-                                msg: format!(
-                                    "Output register {} has not been initialized correctly.",
-                                    &readout
-                                ),
-                            })
+                match readout_register {
+                    None => {
+                        return Err(IqmBackendError::InvalidCircuit {
+                            msg: format!(
+                                "PragmaSetNumberOfMeasurements writes to an undefined register {}",
+                                &readout
+                            ),
+                        })
+                    }
+                    Some(reg) => {
+                        let readout_length = reg
+                            .first()
+                            .expect("Something went wrong when initializing the output registers.")
+                            .len();
+
+                        if measured_qubits.len() > readout_length {
+                            return Err(IqmBackendError::RegisterTooSmall { name: readout });
                         }
-                    };
 
-                    if measured_qubits.len() > readout_length {
-                        return Err(RoqoqoBackendError::GenericError {
-                            msg: format!("PragmaSetNumberOfMeasurements writes to register {}, which is too small.", &readout) });
-                    }
-
-                    // remove MeasureQubit operations
-                    let mut old_measurement_indices = vec![];
-                    for (i, meas) in circuit_vec.iter().enumerate() {
-                        if meas.name == "measure" {
-                            old_measurement_indices.push(i);
+                        // remove MeasureQubit operations
+                        let mut old_measurement_indices = vec![];
+                        for (i, meas) in circuit_vec.iter().enumerate() {
+                            if meas.name == "measure" {
+                                old_measurement_indices.push(i);
+                            }
                         }
-                    }
-                    for i in old_measurement_indices.into_iter().rev() {
-                        circuit_vec.remove(i);
-                    }
+                        // iterate indices in reverse order to avoid shifting the entries of circuit_vec
+                        for i in old_measurement_indices.into_iter().rev() {
+                            circuit_vec.remove(i);
+                        }
 
-                    // update register mapping with the only register specified by PragmaSetNumberOfMeasurements
-                    register_mapping = HashMap::new();
-                    register_mapping.insert(readout.clone(), measured_qubits.clone());
+                        // update register mapping with the only register specified by PragmaSetNumberOfMeasurements
+                        register_mapping = HashMap::new();
+                        register_mapping.insert(readout.clone(), measured_qubits.clone());
 
-                    // add single measurement instruction for all the qubits that were measured with MeasureQubit
-                    let meas = IqmInstruction {
-                        name: "measure".to_string(),
-                        qubits: measured_qubits
-                            .iter()
-                            .map(|x| _convert_qubit_name_qoqo_to_iqm(*x))
-                            .collect(),
-                        args: HashMap::from([("key".to_string(), CalculatorFloat::Str(readout))]),
-                    };
-                    circuit_vec.push(meas)
+                        // add single measurement instruction for all the qubits that were measured with MeasureQubit
+                        let meas = IqmInstruction {
+                            name: "measure".to_string(),
+                            qubits: measured_qubits
+                                .iter()
+                                .map(|x| _convert_qubit_name_qoqo_to_iqm(*x))
+                                .collect(),
+                            args: HashMap::from([(
+                                "key".to_string(),
+                                CalculatorFloat::Str(readout),
+                            )]),
+                        };
+                        circuit_vec.push(meas)
+                    }
                 }
             }
             Operation::PragmaRepeatedMeasurement(o) => {
                 // if number_measurements > 1, it means that it has already been set by either a
                 // PragmaSetNumberOfMeasurements or a PragmaRepeatedMeasurement
                 if number_measurements > 1 {
-                    return Err(RoqoqoBackendError::GenericError {
+                    return Err(IqmBackendError::InvalidCircuit {
                         msg: "Only one repeated measurement is allowed in the circuit.".to_string(),
                     });
                 }
                 if !measured_qubits.is_empty() {
-                    return Err(RoqoqoBackendError::GenericError {
+                    return Err(IqmBackendError::InvalidCircuit {
                         msg: "Some qubits are being measured twice.".to_string(),
                     });
                 }
@@ -241,35 +232,38 @@ pub fn call_circuit<'a>(
 
                 match o.qubit_mapping() {
                     None => {
-                        if output_registers.contains_key(&readout) {
-                            let readout_length = match output_registers
-                                .get(&readout)
-                                .expect("Tried to access a register that is not a key of output_registers.")
-                                .first() {
-                                    Some(v) => v.len(),
-                                    None => return Err(RoqoqoBackendError::GenericError {
-                                        msg: format!("Output register {} has not been initialized correctly.", &readout) })
-                                };
-
-                            register_mapping.insert(
-                                o.readout().to_string(),
-                                (0..readout_length).collect(),
-                            );
-                        } else {
-                            return Err(RoqoqoBackendError::GenericError {
-                                msg: "A PragmaRepeatedMeasurement operation is writing to an undefined register.".to_string() })
+                        match output_registers.get(&readout) {
+                            None => {
+                                return Err(IqmBackendError::InvalidCircuit {
+                                    msg: "A PragmaRepeatedMeasurement operation is writing to an \
+                                           undefined register."
+                                        .to_string(),
+                                })
+                            }
+                            Some(reg) => {
+                                let readout_length = reg
+                                    .first()
+                                    .expect("Something went wrong when initializing the output registers.")
+                                    .len();
+                                register_mapping
+                                    .insert(o.readout().to_string(), (0..readout_length).collect());
+                            }
                         }
                     }
-                    Some(map) => {
-                        match register_mapping.get_mut(o.readout()) {
-                            Some(x) => {
-                                for qubit in map.keys().sorted() {
-                                    x.push(map[qubit])
-                                }},
-                            None => return Err(RoqoqoBackendError::GenericError {
-                                msg: "A PragmaRepeatedMeasurement operation is writing to an undefined register.".to_string() })
+                    Some(map) => match register_mapping.get_mut(o.readout()) {
+                        Some(x) => {
+                            for qubit in map.keys().sorted() {
+                                x.push(map[qubit])
+                            }
                         }
-                    }
+                        None => {
+                            return Err(IqmBackendError::InvalidCircuit {
+                                msg: "A PragmaRepeatedMeasurement operation is writing to an \
+                                     undefined register."
+                                    .to_string(),
+                            })
+                        }
+                    },
                 }
 
                 let measure_all = IqmInstruction {
@@ -283,14 +277,13 @@ pub fn call_circuit<'a>(
                 let reps_ref =
                     o.repetitions()
                         .float()
-                        .map_err(|_| {
-                            RoqoqoBackendError::GenericError {
-                        msg:
-                            "Only Loops with non-symbolic repetitions are supported by the backend."
+                        .map_err(|_| IqmBackendError::InvalidCircuit {
+                            msg: "Only Loops with non-symbolic repetitions are supported by the \
+                                  backend."
                                 .to_string(),
-                    }
                         })?;
                 let reps = (*reps_ref) as i32;
+
                 for _ in 0..reps {
                     for i in o.circuit().iter() {
                         if let Some(instruction) = call_operation(i)? {
@@ -311,7 +304,7 @@ pub fn call_circuit<'a>(
         number_measurements = n
     }
 
-    // Extend output measurements to account for the correct number of shots
+    // Extend output registers to account for the correct number of shots
     if number_measurements > 1 {
         for (_, value) in output_registers.iter_mut() {
             *value = vec![(*value)[0].to_vec(); number_measurements];
@@ -325,6 +318,7 @@ pub fn call_circuit<'a>(
         // irrelevant and is hardcoded
         name: String::from("my_qc"),
         instructions: circuit_vec,
+        metadata: None,
     };
 
     Ok((iqm_circuit, register_mapping, number_measurements))

--- a/roqoqo-iqm/src/interface.rs
+++ b/roqoqo-iqm/src/interface.rs
@@ -17,7 +17,6 @@ use std::f64::consts::PI;
 
 use qoqo_calculator::CalculatorFloat;
 use roqoqo::operations::*;
-use roqoqo::registers::BitOutputRegister;
 use roqoqo::RoqoqoBackendError;
 
 use crate::IqmBackendError;

--- a/roqoqo-iqm/src/lib.rs
+++ b/roqoqo-iqm/src/lib.rs
@@ -75,6 +75,12 @@ pub enum IqmBackendError {
         /// Message
         msg: String,
     },
+    #[error("{msg}")]
+    /// Problem with circuit metadata in the results
+    MetadataError {
+        /// Message
+        msg: String,
+    },
     /// Transparent propagation of RoqoqoBackendError
     #[error(transparent)]
     RoqoqoBackendError(#[from] RoqoqoBackendError),

--- a/roqoqo-iqm/src/lib.rs
+++ b/roqoqo-iqm/src/lib.rs
@@ -10,7 +10,7 @@
 // express or implied. See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Internal roqoqo-iqm
+//! roqoqo-iqm
 //!
 
 #![deny(missing_docs)]
@@ -96,7 +96,7 @@ mod interface;
 pub use interface::{call_circuit, call_operation, IqmCircuit, IqmInstruction};
 
 mod backend;
-pub use backend::Backend;
+pub use backend::*;
 
 pub mod devices;
 pub use devices::*;

--- a/roqoqo-iqm/src/lib.rs
+++ b/roqoqo-iqm/src/lib.rs
@@ -81,6 +81,12 @@ pub enum IqmBackendError {
         /// Message
         msg: String,
     },
+    #[error("{msg}")]
+    /// Received invalid results from the server
+    InvalidResults {
+        /// Message
+        msg: String,
+    },
     /// Transparent propagation of RoqoqoBackendError
     #[error(transparent)]
     RoqoqoBackendError(#[from] RoqoqoBackendError),

--- a/roqoqo-iqm/src/lib.rs
+++ b/roqoqo-iqm/src/lib.rs
@@ -40,7 +40,7 @@ pub enum IqmBackendError {
         /// Job ID
         id: String,
     },
-    /// Abortion of a job has failed.
+    /// Abortion of a job has failed
     #[error("Could not abort job with ID {id}: {msg}")]
     JobAbortionFailed {
         /// Job ID
@@ -48,13 +48,13 @@ pub enum IqmBackendError {
         /// Abort response from the endpoint
         msg: String,
     },
-    /// Result returned by IQM is empty.
+    /// Result returned by IQM is empty
     #[error("IQM has returned an empty result for job with ID {id}.")]
     EmptyResult {
         /// Job ID
         id: String,
     },
-    /// Circuit passed to the backend is empty.
+    /// Circuit passed to the backend is empty
     #[error("An empty circuit was passed to the backend.")]
     EmptyCircuit,
     /// A qubit is being measured multiple times in the qoqo circuit provided.
@@ -69,7 +69,7 @@ pub enum IqmBackendError {
         /// Name of the readout register
         name: String,
     },
-    /// Circuit passed to the backend is invalid.
+    /// Circuit passed to the backend is invalid
     #[error("{msg}")]
     InvalidCircuit {
         /// Message

--- a/roqoqo-iqm/tests/integration/interface.rs
+++ b/roqoqo-iqm/tests/integration/interface.rs
@@ -92,7 +92,7 @@ fn test_call_circuit_repeated_measurement() {
     circuit += operations::PragmaLoop::new(CalculatorFloat::Float(3.0), inner_circuit);
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 10, None);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None)
+    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1)
         .unwrap()
         .0;
 
@@ -143,8 +143,9 @@ fn test_call_circuit_repeated_measurement() {
     instruction_vec.push(meas_instruction);
 
     let res_expected: IqmCircuit = IqmCircuit {
-        name: String::from("my_qc"),
+        name: String::from("qc_1"),
         instructions: instruction_vec,
+        metadata: None,
     };
 
     assert_eq!(res, res_expected)
@@ -160,7 +161,7 @@ fn test_call_circuit_single_measurement() {
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     circuit += operations::MeasureQubit::new(0, "ro".to_string(), 0);
     circuit += operations::MeasureQubit::new(1, "ro".to_string(), 1);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None)
+    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1)
         .unwrap()
         .0;
 
@@ -186,15 +187,16 @@ fn test_call_circuit_single_measurement() {
     let instruction_vec = vec![cz_instruction, xy_instruction, meas_instruction];
 
     let res_expected: IqmCircuit = IqmCircuit {
-        name: String::from("my_qc"),
+        name: String::from("qc_1"),
         instructions: instruction_vec,
+        metadata: None,
     };
 
     assert_eq!(res, res_expected)
 }
 
 #[test]
-fn test_call_circuit_repeated_measurements_with_mappping() {
+fn test_call_circuit_repeated_measurements_with_mapping() {
     let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
     let mut circuit = Circuit::new();
     circuit += operations::ControlledPauliZ::new(0, 1);
@@ -202,7 +204,7 @@ fn test_call_circuit_repeated_measurements_with_mappping() {
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     let qubit_mapping = HashMap::from([(0, 1), (1, 0)]);
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 3, Some(qubit_mapping));
-    let ok = call_circuit(circuit.iter(), 2, &mut bit_registers, None).is_ok();
+    let ok = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1).is_ok();
 
     assert!(ok);
 }
@@ -215,7 +217,7 @@ fn test_fail_multiple_repeated_measurements() {
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     circuit += operations::PragmaSetNumberOfMeasurements::new(5, "ro".to_string());
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 3, None);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None);
+    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1);
 
     assert!(res.is_err());
 }
@@ -228,7 +230,7 @@ fn test_fail_overlapping_measurements() {
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     circuit += operations::MeasureQubit::new(0, "ro".to_string(), 0);
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 3, None);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None);
+    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1);
 
     assert!(res.is_err());
 }

--- a/roqoqo-iqm/tests/integration/interface.rs
+++ b/roqoqo-iqm/tests/integration/interface.rs
@@ -12,7 +12,6 @@
 
 use qoqo_calculator::CalculatorFloat;
 use roqoqo::operations;
-use roqoqo::registers::BitOutputRegister;
 use roqoqo::{Circuit, RoqoqoBackendError};
 use roqoqo_iqm::{call_circuit, call_operation, IqmCircuit, IqmInstruction};
 
@@ -79,22 +78,20 @@ fn test_failure_unsupported_operation(operation: operations::Operation) {
 
 #[test]
 fn test_call_circuit_repeated_measurement() {
-    let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
     let mut inner_circuit = Circuit::new();
     inner_circuit += operations::ControlledPauliZ::new(0, 1);
 
     let mut circuit = Circuit::new();
+    let register_length = 2;
     circuit += operations::ControlledPauliZ::new(0, 1);
     circuit += operations::RotateXY::new(0, PI.into(), PI.into());
     circuit += operations::CZQubitResonator::new(1, 0);
     circuit += operations::SingleExcitationStore::new(5, 0);
     circuit += operations::SingleExcitationLoad::new(5, 0);
     circuit += operations::PragmaLoop::new(CalculatorFloat::Float(3.0), inner_circuit);
-    circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
+    circuit += operations::DefinitionBit::new("ro".to_string(), register_length, true);
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 10, None);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1)
-        .unwrap()
-        .0;
+    let res = call_circuit(circuit.iter(), 2, None, 1).unwrap().0;
 
     let cz_instruction = IqmInstruction {
         name: "cz".to_string(),
@@ -142,10 +139,13 @@ fn test_call_circuit_repeated_measurement() {
     }
     instruction_vec.push(meas_instruction);
 
+    let mut metadata = HashMap::new();
+    metadata.insert("ro".to_string(), (vec![0, 1], register_length));
+
     let res_expected: IqmCircuit = IqmCircuit {
         name: String::from("qc_1"),
         instructions: instruction_vec,
-        metadata: None,
+        metadata: Some(metadata),
     };
 
     assert_eq!(res, res_expected)
@@ -153,17 +153,14 @@ fn test_call_circuit_repeated_measurement() {
 
 #[test]
 fn test_call_circuit_single_measurement() {
-    let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
-
     let mut circuit = Circuit::new();
+    let register_length = 2;
     circuit += operations::ControlledPauliZ::new(0, 1);
     circuit += operations::RotateXY::new(0, PI.into(), PI.into());
-    circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
+    circuit += operations::DefinitionBit::new("ro".to_string(), register_length, true);
     circuit += operations::MeasureQubit::new(0, "ro".to_string(), 0);
     circuit += operations::MeasureQubit::new(1, "ro".to_string(), 1);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1)
-        .unwrap()
-        .0;
+    let res = call_circuit(circuit.iter(), 2, None, 1).unwrap().0;
 
     let cz_instruction = IqmInstruction {
         name: "cz".to_string(),
@@ -186,10 +183,13 @@ fn test_call_circuit_single_measurement() {
 
     let instruction_vec = vec![cz_instruction, xy_instruction, meas_instruction];
 
+    let mut metadata = HashMap::new();
+    metadata.insert("ro".to_string(), (vec![0, 1], register_length));
+
     let res_expected: IqmCircuit = IqmCircuit {
         name: String::from("qc_1"),
         instructions: instruction_vec,
-        metadata: None,
+        metadata: Some(metadata),
     };
 
     assert_eq!(res, res_expected)
@@ -197,40 +197,37 @@ fn test_call_circuit_single_measurement() {
 
 #[test]
 fn test_call_circuit_repeated_measurements_with_mapping() {
-    let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
     let mut circuit = Circuit::new();
     circuit += operations::ControlledPauliZ::new(0, 1);
     circuit += operations::RotateXY::new(0, 1.0.into(), 1.0.into());
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     let qubit_mapping = HashMap::from([(0, 1), (1, 0)]);
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 3, Some(qubit_mapping));
-    let ok = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1).is_ok();
+    let ok = call_circuit(circuit.iter(), 2, None, 1).is_ok();
 
     assert!(ok);
 }
 
 #[test]
 fn test_fail_multiple_repeated_measurements() {
-    let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
     let mut circuit = Circuit::new();
     circuit += operations::ControlledPauliZ::new(0, 1);
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     circuit += operations::PragmaSetNumberOfMeasurements::new(5, "ro".to_string());
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 3, None);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1);
+    let res = call_circuit(circuit.iter(), 2, None, 1);
 
     assert!(res.is_err());
 }
 
 #[test]
 fn test_fail_overlapping_measurements() {
-    let mut bit_registers: HashMap<String, BitOutputRegister> = HashMap::new();
     let mut circuit = Circuit::new();
     circuit += operations::ControlledPauliZ::new(0, 1);
     circuit += operations::DefinitionBit::new("ro".to_string(), 2, true);
     circuit += operations::MeasureQubit::new(0, "ro".to_string(), 0);
     circuit += operations::PragmaRepeatedMeasurement::new("ro".to_string(), 3, None);
-    let res = call_circuit(circuit.iter(), 2, &mut bit_registers, None, 1);
+    let res = call_circuit(circuit.iter(), 2, None, 1);
 
     assert!(res.is_err());
 }


### PR DESCRIPTION
General refactoring to allow for asynchronous execution of jobs on the backend. To this end, information like the lists of measured qubits for each register, used for processing the server response, are not shared internally between functions, but are attached as metadata to the request sent to the server. A copy of the request is sent back with the response, allowing to extract this information from the metadata when asynchronously fetching the results, and use it for post-processing.